### PR TITLE
setup-toolchain.sh: add cctools's ar and ranlib in xctoolchain

### DIFF
--- a/setup-toolchain.sh
+++ b/setup-toolchain.sh
@@ -33,6 +33,8 @@ cd ../../Toolchains/XcodeDefault.xctoolchain/usr/bin
 
 ln -sf $CCTOOLS/bin/libtool .
 ln -sf $CCTOOLS/bin/lipo .
+ln -sf $CCTOOLS/bin/ar .
+ln -sf $CCTOOLS/bin/ranlib .
 cat<<EOF > clang
 #!/bin/bash
 ARGS=()


### PR DESCRIPTION
Without those symlinks, `xcrun -find ar` will return /usr/bin/ar while
on MacOSX it would return .../XcodeDefault.xctoolchain/usr/bin/ar.

With this symlinks, xcrun now returns the path to cctools ar and
`which ar` still returns /usr/bin/ar.

Same rationale applies to ranlib.