### PR TITLE
setup-toolchain.sh: add cctools's as symlink

### DIFF
--- a/setup-toolchain.sh
+++ b/setup-toolchain.sh
@@ -35,6 +35,7 @@ ln -sf $CCTOOLS/bin/libtool .
 ln -sf $CCTOOLS/bin/lipo .
 ln -sf $CCTOOLS/bin/ar .
 ln -sf $CCTOOLS/bin/ranlib .
+ln -sf $CCTOOLS/bin/as .
 cat<<EOF > clang
 #!/bin/bash
 ARGS=()


### PR DESCRIPTION
It allows `xcrun --find as` to return the correct path to the `as`
executable from cctool to match usual MacOSX environment.