### PR TITLE
setup-toolchain: add cctools's missing symlink

### DIFF
--- a/setup-toolchain.sh
+++ b/setup-toolchain.sh
@@ -31,11 +31,14 @@ ln -sf /bin/true ibtool
 
 cd ../../Toolchains/XcodeDefault.xctoolchain/usr/bin
 
-ln -sf $CCTOOLS/bin/libtool .
-ln -sf $CCTOOLS/bin/lipo .
-ln -sf $CCTOOLS/bin/ar .
-ln -sf $CCTOOLS/bin/ranlib .
-ln -sf $CCTOOLS/bin/as .
+TOOLS_SYMLINK="ar as cmpdylib ctf_insert dyldinfo install_name_tool ld libtool"
+TOOLS_SYMLINK="$TOOLS_SYMLINK lipo nmedit pagestuff ranlib segedit size string"
+TOOLS_SYMLINK="$TOOLS_SYMLINK strip unwinddump vtool"
+
+for tool in $TOOLS_SYMLINK; do
+	ln -sf $CCTOOLS/bin/$tool .
+done
+
 cat<<EOF > clang
 #!/bin/bash
 ARGS=()


### PR DESCRIPTION
Add all symlinks from tools that were existing in both cctools and the
MacOSX tools available in the SDK.

It allows `xcrun --find <tool>` to return the correct path to the tool
from cctool requested to match usual MacOSX environment.

Some tools are still missing, being absent from cctools distribution.

Here is  the list of tools currently present in xcode-cross without this PR, the list of tools present in MacOSX SDK and a diff of both showing tools that are not present in xcode-cross.

```
# MacOSX tools
air-ar
air-as
air-libtool
air-link
air-lld
air-nm
air-objdump
air-ranlib
air-readobj
air-size
ar
as
asa
bison
bitcode_strip
c++
c89
c99
cc
clang
clang++
cmpdylib
codesign_allocate
codesign_allocate-p
coremlcompiler
cpp
ctags
ctf_insert
dsymutil
dwarfdump
dwarfdump-classic
dyldinfo
flex
flex++
gcov
gm4
gperf
iig
indent
install_name_tool
ld
lex
libtool
lipo
llvm-cov
llvm-dwarfdump
llvm-nm
llvm-objdump
llvm-otool
llvm-profdata
llvm-size
lorder
m4
metal
metal-ar
metal-as
metal-libtool
metal-link
metal-nm
metal-objdump
metal-ranlib
metal-readobj
metal-size
metallib
mig
nm
nm-classic
nmedit
objdump
otool
otool-classic
pagestuff
ranlib
rpcgen
segedit
size
size-classic
strings
strip
swift
swift-autolink-extract
swift-build
swift-build-tool
swift-demangle
swift-package
swift-run
swift-stdlib-tool
swift-test
swiftc
tapi
unifdef
unifdefall
unwinddump
vtool
yacc
```
```
# xcode-cross tools
ar
as
c++
c89
c99
cc
clang
clang++
dsymutil
g++
gcc
libtool
lipo
nm
ranlib
```

```
# diff macosx xcode_cross_tools
1,10d0
< air-ar
< air-as
< air-libtool
< air-link
< air-lld
< air-nm
< air-objdump
< air-ranlib
< air-readobj
< air-size
13,15d2
< asa
< bison
< bitcode_strip
22,28d8
< cmpdylib
< codesign_allocate
< codesign_allocate-p
< coremlcompiler
< cpp
< ctags
< ctf_insert
30,42c10,11
< dwarfdump
< dwarfdump-classic
< dyldinfo
< flex
< flex++
< gcov
< gm4
< gperf
< iig
< indent
< install_name_tool
< ld
< lex
---
> g++
> gcc
45,65d13
< llvm-cov
< llvm-dwarfdump
< llvm-nm
< llvm-objdump
< llvm-otool
< llvm-profdata
< llvm-size
< lorder
< m4
< metal
< metal-ar
< metal-as
< metal-libtool
< metal-link
< metal-nm
< metal-objdump
< metal-ranlib
< metal-readobj
< metal-size
< metallib
< mig
67,72d14
< nm-classic
< nmedit
< objdump
< otool
< otool-classic
< pagestuff
74,78d15
< rpcgen
< segedit
< size
< size-classic
< strings
< strip
80,95d16
< swift
< swift-autolink-extract
< swift-build
< swift-build-tool
< swift-demangle
< swift-package
< swift-run
< swift-stdlib-tool
< swift-test
< swiftc
< tapi
< unifdef
< unifdefall
< unwinddump
< vtool
< yacc
```